### PR TITLE
fix bug install bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,7 @@
   "description": "A tool to show and add tags to images",
   "main": [
     "dist/taggd.css",
-    "dist/taggd.min.js"
+    "dist/taggd.js"
   ],
   "moduleType": [
     "globals"
@@ -30,5 +30,5 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/timseverien/taggd.git"
-  },
+  }
 }


### PR DESCRIPTION
Bower install doesn't work because of some problems : 
- the file loaded is the min file instead of the standard one
- there is a "," between the 2 end "{"